### PR TITLE
Support for TouchEvents and Handling TouchMove to detect element at position

### DIFF
--- a/example/scripts/wordfindgame.js
+++ b/example/scripts/wordfindgame.js
@@ -97,14 +97,15 @@
       curWord = $(this).text();
     };
 
+
+
     /**
     * Event that handles mouse over on a new square. Ensures that the new square
     * is adjacent to the previous square and the new square is along the path
     * of an actual word.
     *
     */
-    var select = function () {
-
+    var select = function (target) {
       // if the user hasn't started a word yet, just return
       if (!startSquare) {
         return;
@@ -112,7 +113,7 @@
 
       // if the new square is actually the previous square, just return
       var lastSquare = selectedSquares[selectedSquares.length-1];
-      if (lastSquare == this) {
+      if (lastSquare == target) {
         return;
       }
 
@@ -120,7 +121,7 @@
       // they did
       var backTo;
       for (var i = 0, len = selectedSquares.length; i < len; i++) {
-        if (selectedSquares[i] == this) {
+        if (selectedSquares[i] == target) {
           backTo = i+1;
           break;
         }
@@ -138,8 +139,8 @@
       var newOrientation = calcOrientation(
           $(startSquare).attr('x')-0,
           $(startSquare).attr('y')-0,
-          $(this).attr('x')-0,
-          $(this).attr('y')-0
+          $(target).attr('x')-0,
+          $(target).attr('y')-0
           );
 
       if (newOrientation) {
@@ -156,8 +157,8 @@
       var orientation = calcOrientation(
           $(lastSquare).attr('x')-0,
           $(lastSquare).attr('y')-0,
-          $(this).attr('x')-0,
-          $(this).attr('y')-0
+          $(target).attr('x')-0,
+          $(target).attr('y')-0
           );
 
       // if the new square isn't along a valid orientation, just ignore it.
@@ -170,9 +171,20 @@
       // the same orientation as the last move then play the move
       if (!curOrientation || curOrientation === orientation) {
         curOrientation = orientation;
-        playTurn(this);
+        playTurn(target);
       }
 
+    };
+    
+    var touchMove = function(e) {
+      var xPos = e.originalEvent.touches[0].pageX;
+      var yPos = e.originalEvent.touches[0].pageY;
+      var targetElement = document.elementFromPoint(xPos, yPos);
+      select(targetElement)
+    };
+    
+    var mouseMove = function() { 
+      select(this);
     };
 
     /**
@@ -277,8 +289,11 @@
         }
         else {
           $('.puzzleSquare').mousedown(startTurn);
-          $('.puzzleSquare').mouseenter(select);
+          $('.puzzleSquare').mouseenter(mouseMove);
           $('.puzzleSquare').mouseup(endTurn);
+          $('.puzzleSquare').on("touchstart", startTurn);
+          $('.puzzleSquare').on("touchmove", touchMove);
+          $('.puzzleSquare').on("touchend", endTurn);
         }
 
         return puzzle;


### PR DESCRIPTION
Thanks, It's a neat game!, I am using it on the ipad so I added support for touch events.

The ontouchmove event handler's event.touches[0].target always points to the originating HTML element (the item) and not the element which is currently under the finger. The element under the finger needs to be computed var targetElement = document.elementFromPoint(xPos, yPos);
